### PR TITLE
Add levenshtein ratio function

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-General Levenshtein algorithm and k-bounded levenshtein distance algorithm (linear time, constant space) implemented in C as a MySQL UDF.
+General Levenshtein algorithm, k-bounded levenshtein distance algorithm (linear time, constant space), and levenshtein ratio implemented in C as a MySQL UDF.
 
 Installation instructions in the same .c file.
 

--- a/levenshtein.c
+++ b/levenshtein.c
@@ -13,6 +13,7 @@
  *
  * CREATE FUNCTION levenshtein RETURNS INT SONAME 'levenshtein.so';
  * CREATE FUNCTION levenshtein_k RETURNS INT SONAME 'levenshtein.so';
+ * CREATE FUNCTION levenshtein_ratio RETURNS INT SONAME 'levenshtein.so';
  *
  *
  * Some Credit for simple levenshtein to: Joshua Drew, SpinWeb Net Designs


### PR DESCRIPTION
Add a method to compute the ratio between two words. Ordering a result set by the ratio is often more accurate than by the levenshtein distance.

``` SQL
SELECT levenshtein_ratio('Kellogg', 'Kellog');
-- 86
```

MySQL equivalent:

``` SQL
SELECT ROUND((1 - levenshtein('Kellogg', 'Kellog') / GREATEST(LENGTH('Kellogg'), LENGTH('Kellog'))) * 100)
-- 86
```

Consider the following example:

``` SQL
SELECT `name`, levenshtein(`name`, 'Kellog') AS lev, levenshtein_ratio(`name`, 'Kellog') AS lev_ratio
FROM manufacturers
WHERE levenshtein_ratio(`name`, 'Kellog') > 0
ORDER BY lev_ratio DESC;
```

Result:

<table>
<tr><td>Kellogg</td> <td>1</td> <td>86</td></tr>
<tr><td>Kelloggs</td> <td>2</td> <td>75</td></tr>
<tr><td>Kellogg's</td> <td>3</td> <td>67</td></tr>
<tr><td>Kelly's</td> <td>3</td> <td>57</td></tr>
<tr><td>Kallas</td> <td>3</td> <td>50</td></tr>
<tr><td>Kellogg, Co.</td> <td>6</td> <td>50</td></tr>
<tr><td>Kelsey's</td> <td>5</td> <td>38</td></tr>
<tr><td>Klik</td> <td>4</td> <td>33</td></tr>
<tr><td>Klass</td> <td>4</td> <td>33</td></tr>
<tr><td>Kalocsa</td> <td>5</td> <td>29</td></tr>
<tr><td>Ka Lei Eggs</td> <td>8</td> <td>27</td></tr>
<tr><td>Kowalski</td> <td>6</td> <td>25</td></tr>
<tr><td>Kissel's</td> <td>6</td> <td>25</td></tr>
</table>


Without the ratio, 'Kellogg, Co.' would be near the bottom of the result set, instead of closer to the top.

At the end of the day, the SQL required to get the ratio isn't that big of a deal, but having the UDF makes it easier.
