### PR TITLE
Fix an error when compiling on OS X 10.9.3

### DIFF
--- a/levenshtein.c
+++ b/levenshtein.c
@@ -58,6 +58,9 @@ typedef long long longlong;
 /* (Expected) maximum number of digits to return */
 #define LEVENSHTEIN_MAX 3
 
+extern int maximum (int a, int b);
+extern int minimum (int a, int b, int c);
+
 inline int minimum(int a, int b, int c) {
   int min = a;
   if (b < min)


### PR DESCRIPTION
Added declaration for maximum and minimum to avoid the 'Undefined symbols...' error when building.

gcc -bundle -o levenshtein.so levenshtein.c -I/usr/local/mysql/include
Undefined symbols for architecture x86_64:
  "_maximum", referenced from:
      _levenshtein_ratio in levenshtein-9d0d03.o
      _levenshtein_k_ratio in levenshtein-9d0d03.o
  "_minimum", referenced from:
      _levenshtein in levenshtein-9d0d03.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
